### PR TITLE
Fix digest timestamps to use configured timezone (closes #25)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -136,6 +136,7 @@ scoring:
 output:
   max_jobs_in_digest: 0    # 0 = no limit, include all that pass min_score
   sort_by: "score_desc"    # always descending by score
+  timezone: "Europe/Prague"  # IANA timezone for digest timestamps (override via DIGEST_TIMEZONE env var)
 
 # --- Schedule ---
 schedule:

--- a/config_loader.py
+++ b/config_loader.py
@@ -62,6 +62,7 @@ def load_config(config_dir: str | Path | None = None) -> dict[str, Any]:
         "ANTHROPIC_API_KEY": ("anthropic", "api_key"),
         "PROFILE_SUMMARY": ("profile_matcher", "profile_summary"),
         "PROFILE_MATCH_CACHE_PATH": ("profile_matcher", "cache_path"),
+        "DIGEST_TIMEZONE": ("output", "timezone"),
     }
     for env_var, path in env_map.items():
         value = os.environ.get(env_var)

--- a/main.py
+++ b/main.py
@@ -83,7 +83,13 @@ def run(dry_run: bool = False, sources_only: bool = False, score_only: bool = Fa
     config = load_config(Path(__file__).resolve().parent)
 
     logger.info("=" * 60)
-    logger.info("Job Digest Pipeline — %s", datetime.now().strftime("%Y-%m-%d %H:%M"))
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+    tz_name = config.get("output", {}).get("timezone", "UTC")
+    try:
+        _tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        _tz = ZoneInfo("UTC")
+    logger.info("Job Digest Pipeline — %s", datetime.now(_tz).strftime("%Y-%m-%d %H:%M %Z"))
     logger.info("=" * 60)
 
     # ── 1. Fetch from all sources (or load from cache) ──

--- a/output/email_digest.py
+++ b/output/email_digest.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from models import Job
 
@@ -22,11 +23,19 @@ def send_digest(jobs: list[Job], config: dict[str, Any]) -> bool:
         logger.info("No jobs to send — skipping digest.")
         return True
 
-    html = _build_html(jobs)
-    plain = _build_plain(jobs)
+    tz_name = config.get("output", {}).get("timezone", "UTC")
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        logger.warning("Unknown timezone '%s' — falling back to UTC", tz_name)
+        tz = ZoneInfo("UTC")
+    now = datetime.now(tz)
+
+    html = _build_html(jobs, now)
+    plain = _build_plain(jobs, now)
 
     msg = MIMEMultipart("alternative")
-    msg["Subject"] = f"Job Digest — {len(jobs)} matches ({datetime.now().strftime('%d %b %Y')})"
+    msg["Subject"] = f"Job Digest — {len(jobs)} matches ({now.strftime('%d %b %Y')})"
     msg["From"] = email_cfg["sender_email"]
     msg["To"] = email_cfg["recipient_email"]
 
@@ -46,9 +55,9 @@ def send_digest(jobs: list[Job], config: dict[str, Any]) -> bool:
         return False
 
 
-def _build_html(jobs: list[Job]) -> str:
+def _build_html(jobs: list[Job], now: datetime | None = None) -> str:
     """Generate the HTML email body."""
-    today = datetime.now().strftime("%A, %d %B %Y")
+    today = (now or datetime.now()).strftime("%A, %d %B %Y")
 
     rows = ""
     for i, job in enumerate(jobs, 1):
@@ -162,9 +171,9 @@ def _build_html(jobs: list[Job]) -> str:
 </html>"""
 
 
-def _build_plain(jobs: list[Job]) -> str:
+def _build_plain(jobs: list[Job], now: datetime | None = None) -> str:
     """Generate plain-text fallback."""
-    lines = [f"Job Digest — {len(jobs)} matches ({datetime.now().strftime('%d %b %Y')})", "=" * 60, ""]
+    lines = [f"Job Digest — {len(jobs)} matches ({(now or datetime.now()).strftime('%d %b %Y')})", "=" * 60, ""]
 
     for i, job in enumerate(jobs, 1):
         loc = job.location or "N/A"

--- a/output/telegram_digest.py
+++ b/output/telegram_digest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
 
@@ -44,7 +45,8 @@ def send_digest(jobs: list[Job], config: dict[str, Any]) -> bool:
         return True
 
     weights = config.get("scoring", {}).get("weights", {})
-    messages = _build_messages(jobs, weights)
+    tz_name = config.get("output", {}).get("timezone", "UTC")
+    messages = _build_messages(jobs, weights, tz_name)
     url = TELEGRAM_API_URL.format(token=bot_token)
 
     for i, text in enumerate(messages, 1):
@@ -64,9 +66,15 @@ def send_digest(jobs: list[Job], config: dict[str, Any]) -> bool:
     return True
 
 
-def _build_messages(jobs: list[Job], weights: dict[str, int] | None = None) -> list[str]:
+def _build_messages(jobs: list[Job], weights: dict[str, int] | None = None,
+                    tz_name: str = "UTC") -> list[str]:
     """Build a list of messages, splitting if content exceeds Telegram's limit."""
-    now = datetime.now().strftime("%d %b %Y, %H:%M")
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        logger.warning("Unknown timezone '%s' — falling back to UTC", tz_name)
+        tz = ZoneInfo("UTC")
+    now = datetime.now(tz).strftime("%d %b %Y, %H:%M")
     header = f"<b>Job Digest — {now}</b>\n{len(jobs)} matches\n"
     if weights:
         weight_parts = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ requests>=2.31.0
 pyyaml>=6.0
 beautifulsoup4>=4.12.0
 anthropic>=0.50.0
+tzdata>=2024.1
 
 # Testing
 pytest>=7.0


### PR DESCRIPTION
Small follow-up to #20.

- Add `output.timezone` config key (default: `Europe/Prague`) and `DIGEST_TIMEZONE` env var
- Digest headers now show correct CET/CEST time on Railway instead of UTC
- Adds `tzdata` dependency required on Windows and Linux for `zoneinfo`